### PR TITLE
Use env python and py3 compat

### DIFF
--- a/gcloudnfs
+++ b/gcloudnfs
@@ -1,5 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
+from __future__ import print_function
 from googleapiclient import discovery
 from oauth2client.client import GoogleCredentials
 import argparse 
@@ -14,7 +15,7 @@ def get_compute(credentials):
 
 def fail_if_any_none(msg, params):
     if any(map(lambda x : x is None, params)):
-        print msg
+        print(msg)
         sys.exit(1)  
 
 def get_disk_type(zone, disk_type):
@@ -201,4 +202,4 @@ if __name__ == "__main__":
                 args.reuse_data_disk, \
                 args.data_disk_name)
     else:
-        print "No such command %s" % (args.command)
+        print("No such command %s" % (args.command))


### PR DESCRIPTION
This PR has two simple changes:
- Use the env set python rather than directly pointing to one
- Some py3 compatibility with print
